### PR TITLE
Added JS options and ability to specify scroll offset using HTML data tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Simply import the `scrollPosStyler.js` script into your HTML page at the very en
 
 The `.sps--abv` class will be added to your element when the window is scrolled above the defined position, and `.sps--blw` will be applied when it is scrolled below that position.
 
-The default scroll position to trigger the style is 1px, meaning that as soon as the user starts scrolling the CSS class will be toggled. This can be changed with the `scrollOffsetY` variable.
+The default scroll position to trigger the style is 1px, meaning that as soon as the user starts scrolling the CSS class will be toggled. This can be changed by adding the `data-sps-offset` tag in HTML and specifying an offset or by modifying the `scrollOffsetY` variable in JavaScript.
 
 You should add the `.sps--abv` class to the element in your HTML code already, to avoid any flickering when JavaScript is initially executed.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ You should add the `.sps--abv` class to the element in your HTML code already, t
 
 To style elements which were created after the page was initially loaded (i.e. using JavaScript), a public initialization function is available. Simply run `ScrollPosStyler.init()` to add the appropriate class based on the current scroll position. [Demo2](http://acch.github.io/scrollpos-styler/demo/demo2.html) shows you this in action.
 
+The following options can be used in `ScrollPosStyler.init()`:
+
+Name | Type | Default | Description
+--- | --- | --- | ---
+scrollOffsetY | number | 1 | Default scroll position to trigger the style.
+spsClass | string | 'sps' | Classname used to determine which elements to style.
+classAbove | string | 'sps--abv' | Classname added to the elements when the window is scrolled above the defined position.
+classBelow | string | 'sps--blw' | Classname added to the elements when the window is scrolled below the defined position. Default is 'sps--blw'.
+offsetTag | string | 'data-sps-offset' | HTML tag used on the element to speciify a scrollOffsetY other than the default.
+
 ### Dependencies
 
 None. The script does not require jQuery or other JavaScript libraries. While being designed for Bootstrap, it does not require it.

--- a/scrollPosStyler.js
+++ b/scrollPosStyler.js
@@ -21,14 +21,17 @@ var ScrollPosStyler = (function(document, window) {
       // toggle style / class when scrolling below this position (in px)
       scrollOffsetY = 1,
 
+      // class used to apply scrollPosStyler to
+      spsClass = "sps",
+
       // choose elements to apply style / class to
-      elements = document.getElementsByClassName("sps"),
+      elements = document.getElementsByClassName(spsClass),
 
       // style / class to apply to elements when above scroll position
       classAbove = "sps--abv",
 
       // style / class to apply to elements when below scroll position
-      classBelow = "sps--blw";
+      classBelow = "sps--blw",
 
       // tag to set custom scroll offset per element
       offsetTag = "data-sps-offset";
@@ -94,11 +97,30 @@ var ScrollPosStyler = (function(document, window) {
 
   /* ====================
    * public function to initially style elements based on scroll position
+   *
+   * Options:
+   *    scrollOffsetY (integer): Default scroll position to trigger the style. Default is 1.
+   *    spsClass (String): Classname used to determine which elements to style. Default is 'sps'.
+   *    classAbove (String): Classname added to the elements when the window is scrolled above the defined position. Default is 'sps--abv'.
+   *    classBelow (String): Classname added to the elements when the window is scrolled below the defined position. Default is 'sps--blw'.
+   *    offsetTag (String): HTML tag used on the element to speciify a scrollOffsetY other than the default.
+   *
    * ==================== */
   var pub = {
-    init: function() {
+    init: function(options) {
       // suspend accepting scroll events
       busy = true;
+
+      if (options) {
+          if (options.spsClass) {
+              spsClass = options.spsClass;
+              elements = document.getElementsByClassName(spsClass);
+          }
+          scrollOffsetY = options.scrollOffsetY || scrollOffsetY;
+          classAbove = options.classAbove || classAbove;
+          classBelow = options.classBelow || classBelow;
+          offsetTag = options.offsetTag || offsetTag;
+      }
 
       var elementsToUpdate = getElementsToUpdate();
 

--- a/scrollPosStyler.js
+++ b/scrollPosStyler.js
@@ -99,7 +99,7 @@ var ScrollPosStyler = (function(document, window) {
    * public function to initially style elements based on scroll position
    *
    * Options:
-   *    scrollOffsetY (integer): Default scroll position to trigger the style. Default is 1.
+   *    scrollOffsetY (number): Default scroll position to trigger the style. Default is 1.
    *    spsClass (String): Classname used to determine which elements to style. Default is 'sps'.
    *    classAbove (String): Classname added to the elements when the window is scrolled above the defined position. Default is 'sps--abv'.
    *    classBelow (String): Classname added to the elements when the window is scrolled below the defined position. Default is 'sps--blw'.


### PR DESCRIPTION
Added the ability to specify the offset of an element in HTML using the `data-sps-offset` tag.

Added options to `ScrollPosStyler.init()` to be able to specify:
- scrollOffsetY (integer): Default scroll position to trigger the style.
 - spsClass (string): Classname used to determine which elements to style.
 - classAbove (string): Classname added to the elements when the window is scrolled above the defined position.
- classBelow (String): Classname added to the elements when the window is scrolled below the defined position.
- offsetTag (String): HTML tag used on the element to specify a scrollOffsetY other than the default.
